### PR TITLE
fix typo in source file to reflect fix in public/js

### DIFF
--- a/linux/make-web/assets/js/thing/thing.js
+++ b/linux/make-web/assets/js/thing/thing.js
@@ -1,3 +1,3 @@
 App.Checkout = function(){
-  console.log("PPuke on you");
+  console.log("Puke on you");
 };


### PR DESCRIPTION
Not to belabor the 'PPuke' typo fixed in 5c7b379149bd86dad1e3ab03e34fae0742dee4d1, but I noticed a diff in `public` after cloning this repo and going through the exercises myself, so this just fixes it at the source js file as well.

Awesome book so far! 😄 
